### PR TITLE
Grab embed code from the api rather than duplicate it

### DIFF
--- a/includes/themes/media_mediahub.theme.inc
+++ b/includes/themes/media_mediahub.theme.inc
@@ -35,36 +35,15 @@ function media_mediahub_preprocess_media_mediahub_video(&$variables) {
   $variables['url_api'] = 'media/' . $variables['video_id'] . '/file';
   $variables['url'] = url('http://mediahub.unl.edu/' . $variables['url_api'] , array('query' => $variables['query'], 'external' => TRUE, 'https' => TRUE));
 
-  $json = json_decode(@file_get_contents('http://mediahub.unl.edu/media/'.$variables['video_id'].'?format=json'));
+  $service_base_url = 'http://mediahub.unl.edu/';
+  $service_media_link = $service_base_url . 'media/'.$variables['video_id'];
+
+  //set the default output (fall back to just a link)
+  $variables['output'] = '<a href="' . $service_media_link . '">Media</a>';
+
+  //Try to get the embed code via the API
+  $json = json_decode(@file_get_contents($service_media_link.'?format=json'));
   if (isset($json->url)) {
-    // Use the real file path if we are able to.
-    $url = $json->url;
-    // Type is left blank because the type sent by mediahub is incompatible with mediaelement.
-    // For instance a m4v file returns 'video/quicktime' which does not work.
-    $type = '';
-  }
-  else {
-    // If getting the json failed use the /file path which needs a type set.
-    $url = $variables['url'];
-    $type = 'type="video/mp4"';
-  }
-
-  $track = '';
-  if (@file_get_contents('http://mediahub.unl.edu/media/' . $variables['video_id'] . '/vtt')) {
-    $track = "\n" . '        <track src="http://mediahub.unl.edu/media/' . $variables['video_id'] . '/vtt" kind="subtitles" srclang="en" />' . "\n    ";
-  }
-
-  if (isset($json->type) && strrpos($json->type, 'audio') === 0) {
-    $variables['output'] = <<<OUTPUT
-<audio class="wdn_player" preload="auto" src="{$url}"></audio>
-
-OUTPUT;
-  }
-  else {
-  $variables['output'] = <<<OUTPUT
-<video class="wdn_player" style="height:100%;width:100%" src="{$url}" {$type} controls poster="http://mediahub.unl.edu/media/{$variables['video_id']}/image">{$track}</video>
-    <script>WDN.initializePlugin('mediaelement_wdn');</script>
-
-OUTPUT;
+    $variables['output'] = $json->embed;
   }
 }


### PR DESCRIPTION
This will keep the embed code in sync with what mediahub is serving without having to update this module.
